### PR TITLE
[FEAT]: Add Badge Component

### DIFF
--- a/src/stories/WBadge/WBadge.stories.tsx
+++ b/src/stories/WBadge/WBadge.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { COLOR } from '../../types';
+import WBadge from './WBadge';
+
+export default {
+  title: 'Components/WBadge',
+  component: WBadge,
+} as ComponentMeta<typeof WBadge>;
+
+const Template: ComponentStory<typeof WBadge> = (args) => <WBadge {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  children: 'New Badge',
+  color: COLOR['BLUE'],
+  content: 'New',
+  maxCount: 99,
+};

--- a/src/stories/WBadge/WBadge.tsx
+++ b/src/stories/WBadge/WBadge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from 'rsuite';
+
+import { IWBadge } from './types';
+
+const WBadge = (props: IWBadge) => {
+  if (!props) {
+    return null;
+  }
+
+  return <Badge {...props}>{props.children}</Badge>;
+};
+
+export default WBadge;

--- a/src/stories/WBadge/types.ts
+++ b/src/stories/WBadge/types.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+import { COLOR } from '../../types';
+
+export interface IWBadge {
+  children: ReactNode;
+  color: COLOR;
+  content: ReactNode | boolean;
+  maxCount: number;
+}


### PR DESCRIPTION
## Background
Used for buttons, numbers or status markers next to icons.

## Changes done
- Add Badge Component
- Add Story
- Add Type

## Demo
https://user-images.githubusercontent.com/28796557/200361054-86123081-0509-4794-9eac-8990fd3d9b8c.mp4



